### PR TITLE
Setting up ember-cli-github-pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "ember-cli-app-version": "^1.0.0",
     "ember-cli-content-security-policy": "0.4.0",
     "ember-cli-dependency-checker": "^1.1.0",
+    "ember-cli-github-pages": "0.0.6",
     "ember-cli-htmlbars": "^1.0.1",
     "ember-cli-htmlbars-inline-precompile": "^0.3.1",
     "ember-cli-ic-ajax": "0.2.4",


### PR DESCRIPTION
A #fix# to enable ember-cli-github-pages publishing of demos
