### PR TITLE
Fixing the production baseURL property

### DIFF
--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -41,7 +41,7 @@ module.exports = function(environment) {
   }
 
   if (environment === 'production') {
-    baseURL: '/ember-frost-theme'
+    ENV.baseURL: '/ember-frost-theme'
   }
 
   return ENV;


### PR DESCRIPTION
The production baseURL wasn't being set against the ENV - adding a #fix# for this issue.
