### PR TITLE
Default theme and frost-select variables

### DIFF
--- a/scss/_colors.scss
+++ b/scss/_colors.scss
@@ -41,6 +41,6 @@ $frost-color-lgrey-3: #F5F6F7 !default;
 $frost-color-lgrey-4: #F8F9F9 !default;
 $frost-color-lgrey-5: #F2F2F2 !default;
 
-$frost-color-positive: #86C43B!default;
-$frost-color-neutral: #EFC059!default;
-$frost-color-danger: #D1625E!default;
+$frost-color-positive: #86C43B!default; // TODO Should be in a theme an come from the palette (talk to Brain about palette)
+$frost-color-neutral: #EFC059!default; // TODO Should be in a theme an come from the palette (talk to Brain about palette)
+$frost-color-danger: #D1625E!default; // TODO Should be in a theme an come from the palette (talk to Brain about palette)

--- a/scss/_typography.scss
+++ b/scss/_typography.scss
@@ -1,9 +1,0 @@
-$frost-font-family: Roboto, Arial, sans-serif !default;
-
-$frost-font-xxxl: 45px !default;
-$frost-font-xxl: 36px !default;
-$frost-font-xl: 29px !default;
-$frost-font-l: 23px !default;
-$frost-font-m: 18px !default;
-$frost-font-s: 14px !default;
-$frost-font-xs: 12px !default;

--- a/scss/frost-theme.scss
+++ b/scss/frost-theme.scss
@@ -1,7 +1,9 @@
 // Base palette
 @import 'colors';
-@import 'typography';
 
 // Themes
 @import 'themes/default';
 @import 'themes/ember';
+
+// Include the default theme
+@include frost-theme-default;

--- a/scss/themes/_default.scss
+++ b/scss/themes/_default.scss
@@ -1,6 +1,20 @@
 @import '../colors';
 
 @mixin frost-theme-default {
+  // global
+  $frost-input: $frost-color-grey-1 !global;
+  $frost-input-border: $frost-color-lgrey-2 !global;
+  $frost-selection: $frost-color-blue-1 !global;
+  
+  // button
   $frost-button-primary: $frost-color-white !global;
   $frost-button-primary-background: $frost-color-blue-1 !global;
+  $frost-button-tertiary: $frost-color-blue-1 !global;
+  
+  // select
+  $frost-select-container-background: $frost-color-white !global;
+  $frost-select-container-shadow: $frost-color-grey-5 !global;
+  $frost-select-footer-divider: $frost-color-blue-1 !global;
+  $frost-select-indicator: $frost-color-grey-5 !global;
+  $frost-select-item-divider: $frost-color-lgrey-1 !global;
 }

--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -1,5 +1,5 @@
 @import 'frost-theme';
-@include frost-theme-default;
+//@include frost-theme-ember;
 
 .swatches {
   .swatch {


### PR DESCRIPTION
Adding the default theme by default (ha) instead of requiring an explicit @include.  Also added a set of frost-select variables.  No change to the interface (explicit @include still works) so this is a #feature#.
